### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Flashback-RPM-2018/554f8364-0a18-4290-afe1-bd8bfdf3471b/1ddcf3d3-78ff-4ef5-bfb3-d8bc8642495e/_apis/work/boardbadge/65dd99b9-0e2a-48d9-b645-7481281c8984)](https://dev.azure.com/Flashback-RPM-2018/554f8364-0a18-4290-afe1-bd8bfdf3471b/_boards/board/t/1ddcf3d3-78ff-4ef5-bfb3-d8bc8642495e/Microsoft.RequirementCategory)
 # Container Action Template
 
 To get started, click the `Use this template` button on this repository [which will create a new repository based on this template](https://github.blog/2019-06-06-generate-new-repositories-with-repository-templates/).


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Flashback-RPM-2018/554f8364-0a18-4290-afe1-bd8bfdf3471b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.